### PR TITLE
Kill sub-processes when killing the main tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   },
   "dependencies": {
     "execa": "~4.1.0",
-    "@microsoft/rush-lib": "~5.35.2",
+    "@microsoft/rush-lib": "~5.47.0",
     "just-index": "~2.1.0",
     "dag-map": "~2.0.2",
     "chalk": "~4.1.0",
-    "yargs": "~16.0.3"
+    "yargs": "~16.0.3",
+    "terminate": "2.2.0"
   }
 }


### PR DESCRIPTION
This change uses `terminate` package which allows to send a `kill` signal to all child processes when the parent process is asked to terminate via `Ctrl+C`